### PR TITLE
[TS-401] fix modulemap compilation issue with objective c frameworks

### DIFF
--- a/Classes/Bar/JBBarChartView.m
+++ b/Classes/Bar/JBBarChartView.m
@@ -22,13 +22,6 @@ static NSInteger const kJBBarChartViewUndefinedBarIndex = -1;
 // Colors (JBChartView)
 static UIColor *kJBBarChartViewDefaultBarColor = nil;
 
-@interface JBChartView (Private)
-
-- (BOOL)hasMaximumValue;
-- (BOOL)hasMinimumValue;
-
-@end
-
 @interface JBBarChartView () <JBGradientBarViewDataSource>
 
 @property (nonatomic, strong) NSArray *chartData; // index = column, value = height

--- a/Classes/Base/JBChartView.h
+++ b/Classes/Base/JBChartView.h
@@ -151,6 +151,11 @@ typedef NS_ENUM(NSInteger, JBChartViewState){
  */
 - (void)setState:(JBChartViewState)state animated:(BOOL)animated;
 
+#pragma mark - BEGIN Protected Properties and Methods To Be Overriden or Called By Subclasses
+- (BOOL)hasMaximumValue;
+- (BOOL)hasMinimumValue;
+#pragma mark Protected Properties and Methods To Be Overriden or Called By Subclasses END -
+
 @end
 
 /**

--- a/Classes/Line/JBLineChartView.m
+++ b/Classes/Line/JBLineChartView.m
@@ -47,13 +47,6 @@ static CGFloat const kJBLineChartViewDefaultStrokeWidth = 5.0f;
 static NSInteger const kJBLineChartViewDefaultDotRadiusFactor = 3; // 3x size of line width
 static NSInteger const kJBLineChartUnselectedLineIndex = -1;
 
-@interface JBChartView (Private)
-
-- (BOOL)hasMaximumValue;
-- (BOOL)hasMinimumValue;
-
-@end
-
 @interface JBLineChartView () <JBLineChartLinesViewDataSource, JBLineChartDotsViewDataSource>
 
 @property (nonatomic, strong) NSArray *lineChartLines; // Collection of JBLineChartLines

--- a/JBChartView.podspec
+++ b/JBChartView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "JBChartView"
-  s.version      = "3.0.13"
+  s.version      = "3.0.14"
   s.summary      = "Jawbone's iOS-based charting library for both line and bar graphs."
   s.homepage     = "https://github.com/Jawbone/JBChartView"
 
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = { "Terry Worona" => "tworona@jawbone.com" }
   s.source       = { 
 	:git => "https://github.com/Jawbone/JBChartView.git",
-	:tag => "v3.0.13"
+	:tag => "v3.0.14"
   }
 
   s.platform     = :ios, '6.0'


### PR DESCRIPTION
This PR is related to TS-401 and fixed compilation issues on local dev machines and in Circle CI using Xcode 12 in projects with JBChartView installed. The issue is related to modulemap for Objective-C libraries used in Swift iOS projects.

The compile issue in projects using JBChartView was due to private category on `JBChartView` to expose protected methods to subclasses to be called internally. if `@interface JBChartView(Private)` is defined Xcode 12 thinks that there are two definitions of JBChartView type and therefor can't compile the project. The issue happens intermittently when you integrate `JBChartView` into swift projects and happens more often for release builds and occasionally for dev builds. The error looks like this:
```
'JBChartView' defined here has different definitions in different modules; first difference is this method
'JBBarChartView' has different definitions in different modules; defined here
'JBLineChartView' has different definitions in different modules; defined here
```

This PR fixes it by moving protected methods to public header and removing category extension declaration.